### PR TITLE
Improve layout for screens over 900px

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -63,6 +63,8 @@ section {
   color: white;
   overflow: hidden;
   background-color: rgba(0, 0, 0, 0.147);
+  max-width: 600px;
+  justify-self: center;
 }
 
 section > div {
@@ -126,7 +128,6 @@ div#contatti {
 .galleria {
   position: relative;
   width: 100%;
-  max-width: 100%;
   overflow: hidden;
   border-radius: 10px;
   box-shadow: black 0px 0px 12px -5px;
@@ -319,7 +320,7 @@ select {
   cursor: pointer;
 }
 
-@media screen and (max-width: 900px) {
+@media screen and (max-width: 700px) {
   .large {
     display: none;
   }
@@ -329,7 +330,8 @@ select {
     display: none;
   }
 }
-@media screen and (min-width: 901px) {
+
+@media screen and (min-width: 991px) {
   .small,
   .t-small.pic-title {
     display: none;
@@ -352,5 +354,39 @@ select {
 
   .section-more {
     display: none;
+  }
+
+  div#foto {
+    grid-column: 1 / 4;
+  }
+}
+
+@media screen and (min-width: 700px) and (max-width: 990px) {
+  .small,
+  .t-small.pic-title {
+    display: none;
+  }
+
+  #main_page {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1em;
+    padding: 1em;
+  }
+
+  section {
+    flex: initial;
+  }
+
+  section > div {
+    height: 100%;
+  }
+
+  .section-more {
+    display: none;
+  }
+
+  div#foto {
+    grid-column: 1 / 3;
   }
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -126,7 +126,7 @@ div#contatti {
 .galleria {
   position: relative;
   width: 100%;
-  max-width: 991px;
+  max-width: 100%;
   overflow: hidden;
   border-radius: 10px;
   box-shadow: black 0px 0px 12px -5px;
@@ -319,7 +319,7 @@ select {
   cursor: pointer;
 }
 
-@media screen and (max-width: 991px) {
+@media screen and (max-width: 900px) {
   .large {
     display: none;
   }
@@ -329,22 +329,21 @@ select {
     display: none;
   }
 }
-@media screen and (min-width: 991px) {
+@media screen and (min-width: 901px) {
   .small,
   .t-small.pic-title {
     display: none;
   }
 
   #main_page {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around; /* Distribuisce le sezioni uniformemente */
-    gap: 1em; /* Spazio tra le sezioni */
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1em;
     padding: 1em;
   }
 
   section {
-    flex: 1 1 calc(50% - 20px); /* Imposta ogni sezione per occupare il 50% della larghezza del contenitore meno lo spazio per il gap */
+    flex: initial;
   }
 
   section > div {


### PR DESCRIPTION
## Summary
- refine gallery to use container width
- redesign layout for wide screens using grid
- adjust media queries to activate at 900px instead of 991px

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68586f0e5818832ea172910b44397b72